### PR TITLE
[BREAKING CHANGES / PROPOSAL] Parameterize the rating value

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Using itemBuilder
 ![First Way](images/mode1.jpg) 
 ```dart
 RatingBar(
-   initialRating: 3,
+   rating: 3,
    direction: Axis.horizontal,
    allowHalfRating: true,
    itemCount: 5,
@@ -53,7 +53,7 @@ Using rating widgets
 ![Second Way](images/mode2.jpg) 
 ```dart
 RatingBar(
-   initialRating: 3,
+   rating: 3,
    direction: Axis.horizontal,
    allowHalfRating: true,
    itemCount: 5,
@@ -76,7 +76,7 @@ Using item builder with index
 ![Third Way](images/mode3.jpg) 
 ```dart
 RatingBar(
-    initialRating: 3,
+    rating: 3,
     itemCount: 5,
     itemBuilder: (context, index) {
        switch (index) {

--- a/example/README.md
+++ b/example/README.md
@@ -7,7 +7,7 @@
 
 ```dart
 FlutterRatingBar(
-      initialRating: 3,
+      rating: 3,
       fillColor: Colors.amber,
       borderColor: Colors.amber.withAlpha(50),
       allowHalfRating: true,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -219,7 +219,7 @@ class _MyAppState extends State<MyApp> {
     switch (mode) {
       case 1:
         return RatingBar(
-          initialRating: 3,
+          rating: _rating,
           direction: _isVertical ? Axis.vertical : Axis.horizontal,
           allowHalfRating: true,
           unratedColor: Colors.grey[200],
@@ -237,7 +237,7 @@ class _MyAppState extends State<MyApp> {
         );
       case 2:
         return RatingBar(
-          initialRating: 3,
+          rating: 3,
           direction: _isVertical ? Axis.vertical : Axis.horizontal,
           allowHalfRating: true,
           itemCount: 5,
@@ -255,7 +255,7 @@ class _MyAppState extends State<MyApp> {
         );
       case 3:
         return RatingBar(
-          initialRating: 3,
+          rating: 3,
           direction: _isVertical ? Axis.vertical : Axis.horizontal,
           itemCount: 5,
           itemPadding: EdgeInsets.symmetric(horizontal: 4.0),

--- a/lib/flutter_rating_bar.dart
+++ b/lib/flutter_rating_bar.dart
@@ -328,8 +328,8 @@ class RatingBar extends StatefulWidget {
   /// {@endtemplate}
   final int itemCount;
 
-  /// Defines the initial rating to be set to the rating bar.
-  final double initialRating;
+  /// Defines the rating to be set to the rating bar.
+  final double rating;
 
   /// Return current rating whenever rating is updated.
   final ValueChanged<double> onRatingUpdate;
@@ -403,7 +403,7 @@ class RatingBar extends StatefulWidget {
 
   RatingBar({
     this.itemCount = 5,
-    this.initialRating = 0.0,
+    this.rating = 0.0,
     @required this.onRatingUpdate,
     this.itemSize = 40.0,
     this.allowHalfRating = false,
@@ -439,8 +439,8 @@ class _RatingBarState extends State<RatingBar> {
   @override
   void initState() {
     super.initState();
-    _rating = widget.initialRating;
-    _ratingHistory = widget.initialRating;
+    _rating = widget.rating;
+    _ratingHistory = widget.rating;
   }
 
   @override
@@ -452,9 +452,9 @@ class _RatingBarState extends State<RatingBar> {
   @override
   Widget build(BuildContext context) {
     _isRTL = (widget.textDirection ?? Directionality.of(context)) == TextDirection.rtl;
-    if (_ratingHistory != widget.initialRating) {
-      _rating = widget.initialRating;
-      _ratingHistory = widget.initialRating;
+    if (_ratingHistory != widget.rating) {
+      _rating = widget.rating;
+      _ratingHistory = widget.rating;
     }
     iconRating = 0.0;
     return Material(


### PR DESCRIPTION
`flutter_rating_bar` is a pretty nice package.

I'd like to send my proposal to improve this package.

## Description

* Add `rating` property to `RatingBar` widget
* Remove `initialRating` property from `RatingBar` widget

## Motivation

I thought that it would be easier to use the rating value given from outside.

If you worry about a perfomance related widget re-rendering, I partially agree. However, you can choose some trics to prevent re-rendering. (e.g. [ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html) with Consumer)

My PR contains a breaking change by removing the "initialRating" property, feel free to send feedback your opinion.

## Related Issues

https://github.com/sarbagyastha/flutter_rating_bar/issues/22