### PR TITLE
Update flutter_rating_bar.dart

### DIFF
--- a/lib/flutter_rating_bar.dart
+++ b/lib/flutter_rating_bar.dart
@@ -522,7 +522,6 @@ class _RatingBarState extends State<RatingBar> {
         unratedColor: widget.unratedColor ?? Colors.grey[200],
       );
     } else if (index >= _rating - (widget.allowHalfRating ? 0.5 : 1.0) &&
-        index < _rating &&
         widget.allowHalfRating) {
       if (widget.ratingWidget?.half == null) {
         ratingWidget = _HalfRatingWidget(


### PR DESCRIPTION
I guess it is not needed.
first `if` statement `index >= _rating` already sifted