### PR TITLE
emptyItemBuilder added

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,7 +36,7 @@ class _MyAppState extends State<MyApp> {
         appBarTheme: AppBarTheme(
           titleTextStyle: Theme.of(context)
               .textTheme
-              .headline6
+              .headlineSmall
               ?.copyWith(color: Colors.white),
         ),
       ),

--- a/lib/src/rating_bar.dart
+++ b/lib/src/rating_bar.dart
@@ -50,6 +50,7 @@ class RatingBar extends StatefulWidget {
     this.updateOnDrag = false,
     this.wrapAlignment = WrapAlignment.start,
   })  : _itemBuilder = null,
+        _emptyItemBuilder = null,
         _ratingWidget = ratingWidget;
 
   /// Creates [RatingBar] using the [itemBuilder].
@@ -58,6 +59,7 @@ class RatingBar extends StatefulWidget {
     /// Widget for each rating bar item.
     /// {@endtemplate}
     required IndexedWidgetBuilder itemBuilder,
+    IndexedWidgetBuilder? emptyItemBuilder,
     required this.onRatingUpdate,
     this.glowColor,
     this.maxRating,
@@ -77,6 +79,7 @@ class RatingBar extends StatefulWidget {
     this.updateOnDrag = false,
     this.wrapAlignment = WrapAlignment.start,
   })  : _itemBuilder = itemBuilder,
+        _emptyItemBuilder = emptyItemBuilder,
         _ratingWidget = null;
 
   /// Return current rating whenever rating is updated.
@@ -177,6 +180,7 @@ class RatingBar extends StatefulWidget {
   final WrapAlignment wrapAlignment;
 
   final IndexedWidgetBuilder? _itemBuilder;
+  final IndexedWidgetBuilder? _emptyItemBuilder;
   final RatingWidget? _ratingWidget;
 
   @override
@@ -239,6 +243,7 @@ class _RatingBarState extends State<RatingBar> {
   Widget _buildRating(BuildContext context, int index) {
     final ratingWidget = widget._ratingWidget;
     final item = widget._itemBuilder?.call(context, index);
+    final emptyItem = widget._emptyItemBuilder?.call(context, index);
     final ratingOffset = widget.allowHalfRating ? 0.5 : 1.0;
 
     Widget _ratingWidget;
@@ -246,7 +251,7 @@ class _RatingBarState extends State<RatingBar> {
     if (index >= _rating) {
       _ratingWidget = _NoRatingWidget(
         size: widget.itemSize,
-        child: ratingWidget?.empty ?? item!,
+        child: ratingWidget?.empty ?? emptyItem ?? item!,
         enableMask: ratingWidget == null,
         unratedColor: widget.unratedColor ?? Theme.of(context).disabledColor,
       );

--- a/lib/src/rating_bar.dart
+++ b/lib/src/rating_bar.dart
@@ -32,6 +32,7 @@ class RatingBar extends StatefulWidget {
     /// Customizes the Rating Bar item with [RatingWidget].
     required RatingWidget ratingWidget,
     required this.onRatingUpdate,
+    this.onRatingUpdateFinish,
     this.glowColor,
     this.maxRating,
     this.textDirection,
@@ -61,6 +62,7 @@ class RatingBar extends StatefulWidget {
     required IndexedWidgetBuilder itemBuilder,
     IndexedWidgetBuilder? emptyItemBuilder,
     required this.onRatingUpdate,
+    this.onRatingUpdateFinish,
     this.glowColor,
     this.maxRating,
     this.textDirection,
@@ -86,6 +88,10 @@ class RatingBar extends StatefulWidget {
   ///
   /// [updateOnDrag] can be used to change the behaviour how the callback reports the update.
   final ValueChanged<double> onRatingUpdate;
+
+  /// Return rating when user finished dragging.
+  ///
+  final ValueChanged<double>? onRatingUpdateFinish;
 
   /// Defines color for glow.
   ///
@@ -297,6 +303,9 @@ class _RatingBarState extends State<RatingBar> {
     return IgnorePointer(
       ignoring: widget.ignoreGestures,
       child: GestureDetector(
+        onTapUp: (details) {
+          widget.onRatingUpdateFinish?.call(_rating);
+        },
         onTapDown: (details) {
           double value;
           if (index == 0 && (_rating == 1 || _rating == 0.5)) {
@@ -393,6 +402,7 @@ class _RatingBarState extends State<RatingBar> {
   void _onDragEnd(DragEndDetails details) {
     _glow.value = false;
     widget.onRatingUpdate(iconRating);
+    widget.onRatingUpdateFinish?.call(iconRating);
     iconRating = 0.0;
   }
 }

--- a/lib/src/rating_bar_indicator.dart
+++ b/lib/src/rating_bar_indicator.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 class RatingBarIndicator extends StatefulWidget {
   RatingBarIndicator({
     required this.itemBuilder,
+    this.emptyItemBuilder,
     this.textDirection,
     this.unratedColor,
     this.direction = Axis.horizontal,
@@ -21,6 +22,9 @@ class RatingBarIndicator extends StatefulWidget {
 
   /// {@macro flutterRatingBar.itemBuilder}
   final IndexedWidgetBuilder itemBuilder;
+
+  /// {@macro flutterRatingBar.emptyItemBuilder}
+  final IndexedWidgetBuilder? emptyItemBuilder;
 
   /// {@macro flutterRatingBar.textDirection}
   final TextDirection? textDirection;
@@ -122,13 +126,15 @@ class _RatingBarIndicatorState extends State<RatingBarIndicator> {
               fit: BoxFit.contain,
               child: index + 1 < _ratingNumber
                   ? widget.itemBuilder(context, index)
-                  : ColorFiltered(
-                      colorFilter: ColorFilter.mode(
-                        widget.unratedColor ?? Theme.of(context).disabledColor,
-                        BlendMode.srcIn,
+                  : widget.emptyItemBuilder?.call(context, index) ??
+                      ColorFiltered(
+                        colorFilter: ColorFilter.mode(
+                          widget.unratedColor ??
+                              Theme.of(context).disabledColor,
+                          BlendMode.srcIn,
+                        ),
+                        child: widget.itemBuilder(context, index),
                       ),
-                      child: widget.itemBuilder(context, index),
-                    ),
             ),
             if (index + 1 == _ratingNumber)
               if (_isRTL)


### PR DESCRIPTION
emptyItemBuilder added to support customizations on empty items when using RatingBar.builder(...) and RatingBarIndicator(...)
Useful when you want a rating bar with 5 different symbols for active rating and other 5 different symbols for empty rating.
