### PR TITLE
Set hit test behavior to opaque to prevent targets visually behind th…

### DIFF
--- a/lib/src/rating_bar.dart
+++ b/lib/src/rating_bar.dart
@@ -294,6 +294,7 @@ class _RatingBarState extends State<RatingBar> {
     return IgnorePointer(
       ignoring: widget.ignoreGestures,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTapDown: (details) {
           double value;
           if (index == 0 && (_rating == 1 || _rating == 0.5)) {


### PR DESCRIPTION
It is difficult to tap or drag widgets with a small paint area. Setting gesture detector behavior to HitTestBehavior.opaque fixes this issue as it prevents targets visually behind them from receiving events.