### PR TITLE
Enforce maxRating limit in RatingBar value calculation

### DIFF
--- a/lib/src/rating_bar.dart
+++ b/lib/src/rating_bar.dart
@@ -315,6 +315,8 @@ class _RatingBarState extends State<RatingBar> {
           }
 
           value = math.max(value, widget.minRating);
+          value =
+              math.min(value, widget.maxRating ?? widget.itemCount.toDouble());
           widget.onRatingUpdate(value);
           _rating = value;
           setState(() {});


### PR DESCRIPTION
Dear sarbagyastha

**Issue:**
We observed that tapping on the rating bar could inadvertently allow users to set a rating higher than the `maxRating`, which should not be possible. This inconsistency can lead to unexpected behavior, particularly when a specific `maxRating` is set.

**Implemented Fix:**
To resolve this, I have adjusted the rating calculation logic to ensure that the rating value does not go beyond `maxRating` when the widget is tapped. The key change is:
```dart
value = math.min(value, widget.maxRating ?? widget.itemCount.toDouble());
```
Here is a video of the issue

https://github.com/sarbagyastha/flutter_rating_bar/assets/70211082/7cc0afc4-1b00-4db6-a9c5-96daba658267


Thank you for your time.